### PR TITLE
added apostrophes to make congig.js sample work out of the box

### DIFF
--- a/config.js.template
+++ b/config.js.template
@@ -37,10 +37,10 @@ config.oauth = {
 // Keystone configuration.
 config.keystone = {
 	host: '',
-	port: ,
+	port: '',
 	admin_host: '',
-	admin_port: , 
-	username: '', 
+	admin_port: '', 
+	username: '',
 	password: '',
 	tenantId: ''
 };


### PR DESCRIPTION
I noticed that the sample config.js was giving this error:

/p/test/cloudportal/config.js:40
    port: ,
          ^
SyntaxError: Unexpected token ,
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/p/test/cloudportal/server.js:8:14)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)

So I added the apostrophes to make the sample work out of the box.
